### PR TITLE
Strip leading 0s from Pubmed IDs

### DIFF
--- a/lib/identifiers/pubmed_id.rb
+++ b/lib/identifiers/pubmed_id.rb
@@ -1,7 +1,9 @@
 module Identifiers
   class PubmedId
     def self.extract(str)
-      str.scan(/(?<=^|\s)\d+(?=$|\s)/)
+      str
+        .scan(/(?<=^|\s)0*(?!0)(\d+)(?=$|\s)/)
+        .flatten
     end
   end
 end

--- a/spec/identifiers/pubmed_id_spec.rb
+++ b/spec/identifiers/pubmed_id_spec.rb
@@ -10,4 +10,12 @@ RSpec.describe Identifiers::PubmedId do
 
     expect(described_class.extract(str)).to be_empty
   end
+
+  it 'strips leading 0s' do
+    expect(described_class.extract("0000010203\n000456000")).to contain_exactly('10203', '456000')
+  end
+
+  it 'does not consider 0 as a valid Pubmed ID' do
+    expect(described_class.extract("00000000")).to be_empty
+  end
 end


### PR DESCRIPTION
- strip leading 0s from any Pubmed IDs (`0000010203` returns `10203`)
- `0` is no longer considered a valid Pubmed ID