### PR TITLE
Convert of ISBN-10s to 13 with a check digit of 10

### DIFF
--- a/lib/identifiers/isbn.rb
+++ b/lib/identifiers/isbn.rb
@@ -22,7 +22,14 @@ module Identifiers
     end
 
     def self.isbn_13_check_digit(isbn)
-      10 - isbn.each_char.zip([1, 3].cycle).reduce(0) { |sum, values| sum + (Integer(values[0]) * values[1]) } % 10
+      sum = isbn.each_char.zip([1, 3].cycle).reduce(0) { |sum, values| sum + (Integer(values[0]) * values[1]) }
+      check_digit = 10 - (sum % 10)
+
+      if check_digit == 10
+        0
+      else
+        check_digit
+      end
     end
 
     def self.valid_isbn_13?(isbn)

--- a/spec/identifiers/isbn_spec.rb
+++ b/spec/identifiers/isbn_spec.rb
@@ -13,7 +13,12 @@ RSpec.describe Identifiers::ISBN do
 
   it 'normalizes 10-digit ISBNs' do
     str = "0-8050-6909-7 \n 2-7594-0269-X"
+
     expect(described_class.extract(str)).to contain_exactly('9780805069099', '9782759402694')
+  end
+
+  it 'normalizes 10-digit ISBNs with a check digit of 10' do
+    expect(described_class.extract('4423272350')).to contain_exactly('9784423272350')
   end
 
   it 'does not extract invalid 13-digit ISBNs' do


### PR DESCRIPTION
When converting an ISBN-10 to an ISBN-13, we missed an important special case when calculating the new check digit: when the calculated digit is 10, it should be replaced with a 0.