### PR TITLE
Update regex to fit better understanding of format of DOI

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,6 +66,14 @@ But for some identifiers might have more. Check [their implementation](https://g
 
 For `URN`s, please check the [URN gem documentation](https://github.com/altmetric/urn) to see all the available options.
 
+### DOIs
+
+DOI's are notoriously tricky to pin down in a regex, since the actual regex could feasibly be `10\.{\d}+/\S+` in order to match all possible DOIs.
+
+The regular expression we use is taken from a [CrossRef article](http://blog.crossref.org/2015/08/doi-regular-expressions.html) describing a sane way of matching 74.4M of their 74.9M registered DOIs (as of 2015). Additionally, the library will seek out a portion of more unusual looking DOIs (predominately used by Wiley). This catches around 300k extra IDs. The blog post goes into extra regexs, however they'll add more false positives.
+
+It should be noted that we do not make attempts to clean up the DOIs. You may well find punction at the end of the extracted DOI, or invalid Unicode characters. This will depend on the quality of the source you're scraping.
+
 ## Contributing
 
 Bug reports and pull requests are welcome on GitHub at https://github.com/altmetric/identifiers.

--- a/lib/identifiers/doi.rb
+++ b/lib/identifiers/doi.rb
@@ -1,7 +1,10 @@
 module Identifiers
   class DOI
     def self.extract(str)
-      str.scan(%r{\b10\.\d{3,}/\S+\b}).map(&:downcase)
+      most_dois = %r{\b10.\d{4,9}/[-._;()/:A-Z0-9]+\b}i
+      old_wiley_dois = %r{^10.1002/[^\s]+}
+
+      str.scan(Regexp.union([most_dois, old_wiley_dois])).map(&:downcase)
     end
   end
 end

--- a/spec/identifiers/doi_spec.rb
+++ b/spec/identifiers/doi_spec.rb
@@ -2,15 +2,27 @@ require 'identifiers/doi'
 
 RSpec.describe Identifiers::DOI do
   it 'extracts DOIs from a string' do
-    str = 'This is an example of DOI: 10.1049/el.2013.3006'
+    str = 'This is an example of DOI: 10.1049/el.2013.3006 and here is some content after it'
 
     expect(described_class.extract(str)).to contain_exactly('10.1049/el.2013.3006')
+  end
+
+  it 'extracts multiple DOIs from a string' do
+    str = 'This is an example of DOI: 10.1049/el.2013.3006 and here is a second one: 10.1016/0041-0101(94)90134-1'
+
+    expect(described_class.extract(str)).to contain_exactly('10.1049/el.2013.3006', '10.1016/0041-0101(94)90134-1')
   end
 
   it 'downcase the DOIs extracted' do
     str = 'This is an example of DOI: 10.1097/01.ASW.0000443266.17665.19'
 
     expect(described_class.extract(str)).to contain_exactly('10.1097/01.asw.0000443266.17665.19')
+  end
+
+  it 'avoids DOIs which look surprisingly like DOIs, but are not' do
+    str = 'This is an example of an invalid DOI: 10.111/j.1746-692x.2008.00078.x'
+
+    expect(described_class.extract(str)).to be_empty
   end
 
   it 'does not extract a PUBMED ID' do


### PR DESCRIPTION
Reading a post by Andrew Gimartin (
http://blog.crossref.org/2015/08/doi-regular-expressions.html ) it seems
that there's a regex which fits the majority of Crossref DOIs, and
it seems generic enough to work with other providers also.