### PR TITLE
Support ISBNs separated with spaces

### DIFF
--- a/lib/identifiers/isbn.rb
+++ b/lib/identifiers/isbn.rb
@@ -8,11 +8,11 @@ module Identifiers
     end
 
     def self.extract_thirteen_digit_isbns(str)
-      str.tr('-', '').scan(REGEX_13).select { |isbn| valid_isbn_13?(isbn) }
+      str.gsub(/(?<=\d)[- ](?=\d)/, '').scan(REGEX_13).select { |isbn| valid_isbn_13?(isbn) }
     end
 
     def self.extract_ten_digit_isbns(str)
-      str.tr('-', '').scan(REGEX_10).select { |isbn| valid_isbn_10?(isbn) }.map { |isbn|
+      str.gsub(/(?<=\d)[- ](?=[\dX])/i, '').scan(REGEX_10).select { |isbn| valid_isbn_10?(isbn) }.map { |isbn|
         isbn.chop!
         isbn.prepend('978')
         isbn << isbn_13_check_digit(isbn).to_s

--- a/spec/identifiers/isbn_spec.rb
+++ b/spec/identifiers/isbn_spec.rb
@@ -11,6 +11,14 @@ RSpec.describe Identifiers::ISBN do
     expect(described_class.extract(str)).to contain_exactly('9780805069099', '9780671879198')
   end
 
+  it 'extracts ISBNs with hyphens' do
+    expect(described_class.extract('ISBN: 978-0-80-506909-9')).to contain_exactly('9780805069099')
+  end
+
+  it 'extracts ISBNs with spaces' do
+    expect(described_class.extract('ISBN: 978 0 80 506909 9')).to contain_exactly('9780805069099')
+  end
+
   it 'normalizes 10-digit ISBNs' do
     str = "0-8050-6909-7 \n 2-7594-0269-X"
 
@@ -19,6 +27,14 @@ RSpec.describe Identifiers::ISBN do
 
   it 'normalizes 10-digit ISBNs with a check digit of 10' do
     expect(described_class.extract('4423272350')).to contain_exactly('9784423272350')
+  end
+
+  it 'normalizes 10-digit ISBNs with spaces' do
+    expect(described_class.extract('0 8050 6909 7')).to contain_exactly('9780805069099')
+  end
+
+  it 'normalizes 10-digit ISBNs with spaces and a check digit of X' do
+    expect(described_class.extract('2 7594 0269 X')).to contain_exactly('9782759402694')
   end
 
   it 'does not extract invalid 13-digit ISBNs' do


### PR DESCRIPTION
As ISBNs can officially [0] be separated with spaces as well as hyphens, support the extraction of identifiers with spaces. Note that we are now stricter about removing hyphens so that it is only done between digits or an X check digit.

  [0]: https://www.isbn-international.org/content/what-isbn