### PR TITLE
Add support for ISBN-As when extracting DOIs

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ Collection of utilities related to the extraction, validation and normalization 
 
 - [ADS Bibcodes](http://adsdoc.harvard.edu/abs_doc/help_pages/bibcodes.html)
 - [arXiv IDs](https://arxiv.org/help/arxiv_identifier)
-- [DOIs](https://www.doi.org/)
+- [DOIs](https://www.doi.org/) (including [ISBN-As](https://www.doi.org/factsheets/ISBN-A.html))
 - [Handles](https://en.wikipedia.org/wiki/Handle_System)
 - [ISBNs](https://en.wikipedia.org/wiki/International_Standard_Book_Number)
 - [National Clinical Trial IDs](https://clinicaltrials.gov/)

--- a/lib/identifiers/doi.rb
+++ b/lib/identifiers/doi.rb
@@ -1,7 +1,7 @@
 module Identifiers
   class DOI
     def self.extract(str)
-      str.scan(%r{\b10\.\d{3,}/\S+\b}).map(&:downcase)
+      str.scan(%r{\b10\.(?:97[89]\.\d{2,8}/\d{1,7}|\d{4,9}/\S+)\b}).map(&:downcase)
     end
   end
 end

--- a/lib/identifiers/isbn.rb
+++ b/lib/identifiers/isbn.rb
@@ -2,9 +2,14 @@ module Identifiers
   class ISBN
     REGEX_13 = /\b97[89]\d{10}\b/
     REGEX_10 = /\b\d{9}(?:\d|X)\b/
+    REGEX_A = %r{\b(?<=10\.)97[89]\.\d{2,8}/\d{1,7}\b}
 
     def self.extract(str)
-      extract_thirteen_digit_isbns(str) + extract_ten_digit_isbns(str)
+      extract_isbn_as(str) + extract_thirteen_digit_isbns(str) + extract_ten_digit_isbns(str)
+    end
+
+    def self.extract_isbn_as(str)
+      extract_thirteen_digit_isbns(str.scan(REGEX_A).join("\n").tr('/.', ''))
     end
 
     def self.extract_thirteen_digit_isbns(str)

--- a/spec/identifiers/doi_spec.rb
+++ b/spec/identifiers/doi_spec.rb
@@ -13,8 +13,20 @@ RSpec.describe Identifiers::DOI do
     expect(described_class.extract(str)).to contain_exactly('10.1097/01.asw.0000443266.17665.19')
   end
 
-  it 'does not extract a PUBMED ID' do
+  it 'does not extract a PubMed ID' do
     str = 'This is NOT a DOI: 123456'
+
+    expect(described_class.extract(str)).to be_empty
+  end
+
+  it 'extracts ISBN-As' do
+    str = 'This is an ISBN-A: 10.978.8898392/315'
+
+    expect(described_class.extract(str)).to contain_exactly('10.978.8898392/315')
+  end
+
+  it 'does not extract invalid ISBN-As' do
+    str = 'This is not an ISBN-A: 10.978.8898392/NotARealIsbnA'
 
     expect(described_class.extract(str)).to be_empty
   end

--- a/spec/identifiers/isbn_spec.rb
+++ b/spec/identifiers/isbn_spec.rb
@@ -19,6 +19,14 @@ RSpec.describe Identifiers::ISBN do
     expect(described_class.extract('ISBN: 978 0 80 506909 9')).to contain_exactly('9780805069099')
   end
 
+  it 'extracts ISBN-13s from ISBN-As' do
+    expect(described_class.extract('10.978.8898392/315')).to contain_exactly('9788898392315')
+  end
+
+  it 'does not extract invalid ISBNs from ISBN-As' do
+    expect(described_class.extract('10.978.8898392/316')).to be_empty
+  end
+
   it 'normalizes 10-digit ISBNs' do
     str = "0-8050-6909-7 \n 2-7594-0269-X"
 


### PR DESCRIPTION
As the DOI system can be used to express ISBNs in the form of ISBN-As and this was not supported by our pattern matching, explicitly add support for ISBN-As when extracting DOIs.

See https://www.doi.org/factsheets/ISBN-A.html for more information about the format.