### PR TITLE
Add support for capturing DOIs with trailing (selective) punctionation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 All notable changes to this project will be documented in this file. This
 project adheres to [Semantic Versioning](http://semver.org/).
 
+## [0.6.0] - 2017-04-04
+### Changed
+- Extract closing parens from DOIs
+
 ## [0.5.0] - 2017-01-27
 ### Added
 - Added support for ISBN-As when extracting DOIs and ISBNs
@@ -32,3 +36,4 @@ project adheres to [Semantic Versioning](http://semver.org/).
 [0.3.1]: https://github.com/altmetric/identifiers/releases/tag/v0.3.1
 [0.4.0]: https://github.com/altmetric/identifiers/releases/tag/v0.4.0
 [0.5.0]: https://github.com/altmetric/identifiers/releases/tag/v0.5.0
+[0.6.0]: https://github.com/altmetric/identifiers/releases/tag/v0.6.0

--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ Collection of utilities related to the extraction, validation and normalization 
 Add this line to your application's `Gemfile`:
 
 ```ruby
-gem 'identifiers', '~> 0.5'
+gem 'identifiers', '~> 0.6'
 ```
 
 And then execute:

--- a/identifiers.gemspec
+++ b/identifiers.gemspec
@@ -1,6 +1,6 @@
 Gem::Specification.new do |spec|
   spec.name          = 'identifiers'
-  spec.version       = '0.5.0'
+  spec.version       = '0.6.0'
   spec.authors       = ['Jonathan Hernandez', 'Paul Mucur']
   spec.email         = ['support@altmetric.com']
 

--- a/lib/identifiers/doi.rb
+++ b/lib/identifiers/doi.rb
@@ -1,7 +1,7 @@
 module Identifiers
   class DOI
     def self.extract(str)
-      str.scan(%r{\b10\.(?:97[89]\.\d{2,8}/\d{1,7}|\d{4,9}/\S+)}).map(&:downcase)
+      str.scan(%r{\b10\.(?:97[89]\.\d{2,8}/\d{1,7}|\d{4,9}/\S*(?![\p{Punct}&&[^)]])\S)}x).map(&:downcase)
     end
   end
 end

--- a/lib/identifiers/doi.rb
+++ b/lib/identifiers/doi.rb
@@ -1,7 +1,7 @@
 module Identifiers
   class DOI
     def self.extract(str)
-      str.scan(%r{\b10\.(?:97[89]\.\d{2,8}/\d{1,7}|\d{4,9}/\S+)\b}).map(&:downcase)
+      str.scan(%r{\b10\.(?:97[89]\.\d{2,8}/\d{1,7}|\d{4,9}/\S+)}).map(&:downcase)
     end
   end
 end

--- a/spec/identifiers/doi_spec.rb
+++ b/spec/identifiers/doi_spec.rb
@@ -7,6 +7,12 @@ RSpec.describe Identifiers::DOI do
     expect(described_class.extract(str)).to contain_exactly('10.1049/el.2013.3006')
   end
 
+  it 'extracts DOIs from any where in a string' do
+    str = 'This is an example of DOI - 10.1049/el.2013.3006 - which is entirely valid'
+
+    expect(described_class.extract(str)).to contain_exactly('10.1049/el.2013.3006')
+  end
+
   it 'downcase the DOIs extracted' do
     str = 'This is an example of DOI: 10.1097/01.ASW.0000443266.17665.19'
 
@@ -29,5 +35,11 @@ RSpec.describe Identifiers::DOI do
     str = 'This is not an ISBN-A: 10.978.8898392/NotARealIsbnA'
 
     expect(described_class.extract(str)).to be_empty
+  end
+
+  it 'retains potentially valid trailing punctuation' do
+    str = 'This is an example of DOI: 10.1130/2013.2502(04)'
+
+    expect(described_class.extract(str)).to contain_exactly('10.1130/2013.2502(04)')
   end
 end

--- a/spec/identifiers/doi_spec.rb
+++ b/spec/identifiers/doi_spec.rb
@@ -42,4 +42,10 @@ RSpec.describe Identifiers::DOI do
 
     expect(described_class.extract(str)).to contain_exactly('10.1130/2013.2502(04)')
   end
+
+  it 'does not extract periods on a DOI' do
+    str = 'This is an example of DOI: 10.1049/el.2013.3006.'
+
+    expect(described_class.extract(str)).to contain_exactly('10.1049/el.2013.3006')
+  end
 end


### PR DESCRIPTION
This comes with trade offs of course.

The downside of this PR is that this example will incorrectly pick up the closing bracket:

> "(for more information, see the DOI 10.2345/somedoiorother)"

The upside is that we now correctly pick up this DOI:

> 10.1130/2013.2502(04)