### PR TITLE
Support balanced parentheses at the end of DOIs

### DIFF
--- a/lib/identifiers/doi.rb
+++ b/lib/identifiers/doi.rb
@@ -1,7 +1,7 @@
 module Identifiers
   class DOI
     def self.extract(str)
-      str.scan(%r{\b10\.(?:97[89]\.\d{2,8}/\d{1,7}|\d{4,9}/\S+)\b}).map(&:downcase)
+      str.scan(%r{\b10\.(?:97[89]\.\d{2,8}/\d{1,7}|\d{4,9}/\S+)}).map(&:downcase)
     end
   end
 end

--- a/lib/identifiers/doi.rb
+++ b/lib/identifiers/doi.rb
@@ -17,14 +17,26 @@ module Identifiers
         \S+     # DOI suffix
       )
     }x
+    VALID_ENDING = /
+      (?:
+        \p{^Punct}  # Non-punctuation character
+        |
+        \(.+\)      # Balanced parentheses
+        |
+        2-\#        # Early Wiley DOI suffix
+      )
+      \z
+    /x
 
     def self.extract(str)
       str
+        .to_s
+        .downcase
         .scan(PATTERN)
         .map { |doi|
-          next doi.downcase if doi !~ /\p{Punct}\z/ || doi =~ /\(.+\)\z/
+          next doi if doi =~ VALID_ENDING
 
-          doi.downcase.chop
+          doi.sub(/\p{Punct}+\z/, '')
         }
     end
   end

--- a/lib/identifiers/doi.rb
+++ b/lib/identifiers/doi.rb
@@ -1,7 +1,31 @@
 module Identifiers
   class DOI
+    PATTERN = %r{
+      \b
+      10 # Directory indicator (always 10)
+      \.
+      (?:
+        # ISBN-A
+        97[89]\. # ISBN (GS1) Bookland prefix
+        \d{2,8}  # ISBN registration group element and publisher prefix
+        /        # Prefix/suffix divider
+        \d{1,7}  # ISBN title enumerator and check digit
+        |
+        # DOI
+        \d{4,9} # Registrant code
+        /       # Prefix/suffix divider
+        \S+     # DOI suffix
+      )
+    }x
+
     def self.extract(str)
-      str.scan(%r{\b10\.(?:97[89]\.\d{2,8}/\d{1,7}|\d{4,9}/\S+)}).map(&:downcase)
+      str
+        .scan(PATTERN)
+        .map { |doi|
+          next doi.downcase if doi !~ /\p{Punct}\z/ || doi =~ /\(.+\)\z/
+
+          doi.downcase.chop
+        }
     end
   end
 end

--- a/spec/identifiers/doi_spec.rb
+++ b/spec/identifiers/doi_spec.rb
@@ -2,19 +2,19 @@ require 'identifiers/doi'
 
 RSpec.describe Identifiers::DOI do
   it 'extracts DOIs from a string' do
-    str = 'This is an example of DOI: 10.1049/el.2013.3006'
+    str = 'This is an example of a DOI: 10.1049/el.2013.3006'
 
     expect(described_class.extract(str)).to contain_exactly('10.1049/el.2013.3006')
   end
 
   it 'extracts DOIs from anywhere in a string' do
-    str = 'This is an example of DOI - 10.1049/el.2013.3006 - which is entirely valid'
+    str = 'This is an example of a DOI - 10.1049/el.2013.3006 - which is entirely valid'
 
     expect(described_class.extract(str)).to contain_exactly('10.1049/el.2013.3006')
   end
 
-  it 'downcase the DOIs extracted' do
-    str = 'This is an example of DOI: 10.1097/01.ASW.0000443266.17665.19'
+  it 'downcases the DOIs extracted' do
+    str = 'This is an example of a DOI: 10.1097/01.ASW.0000443266.17665.19'
 
     expect(described_class.extract(str)).to contain_exactly('10.1097/01.asw.0000443266.17665.19')
   end
@@ -23,6 +23,10 @@ RSpec.describe Identifiers::DOI do
     str = 'This is NOT a DOI: 123456'
 
     expect(described_class.extract(str)).to be_empty
+  end
+
+  it 'returns no DOIs if given nothing' do
+    expect(described_class.extract(nil)).to be_empty
   end
 
   it 'extracts ISBN-As' do
@@ -38,19 +42,37 @@ RSpec.describe Identifiers::DOI do
   end
 
   it 'retains closing parentheses that are part of the DOI' do
-    str = 'This is an example of DOI: 10.1130/2013.2502(04)'
+    str = 'This is an example of a DOI: 10.1130/2013.2502(04)'
 
     expect(described_class.extract(str)).to contain_exactly('10.1130/2013.2502(04)')
   end
 
   it 'discards trailing punctuation' do
-    str = 'This is an example of DOI: 10.1130/2013.2502.'
+    str = 'This is an example of a DOI: 10.1130/2013.2502.'
 
     expect(described_class.extract(str)).to contain_exactly('10.1130/2013.2502')
   end
 
+  it 'discards multiple contiguous trailing punctuation' do
+    str = 'This is an example of a DOI: 10.1130/2013.2502...",'
+
+    expect(described_class.extract(str)).to contain_exactly('10.1130/2013.2502')
+  end
+
+  it 'discards trailing Unicode punctuation' do
+    str = 'This is an example of a DOI: 10.1130/2013.2502…'
+
+    expect(described_class.extract(str)).to contain_exactly('10.1130/2013.2502')
+  end
+
+  it 'extracts particularly exotic DOIs' do
+    str = 'This is an example of an exotic DOI: 10.1002/(SICI)1096-8644(199601)99:1<135::AID-AJPA8>3.0.CO;2-#'
+
+    expect(described_class.extract(str)).to contain_exactly('10.1002/(sici)1096-8644(199601)99:1<135::aid-ajpa8>3.0.co;2-#')
+  end
+
   it 'does not extract a closing parenthesis if not part of the DOI' do
-    str = '(This is an example of DOI: 10.1130/2013.2502)'
+    str = '(This is an example of a DOI: 10.1130/2013.2502)'
 
     expect(described_class.extract(str)).to contain_exactly('10.1130/2013.2502')
   end

--- a/spec/identifiers/doi_spec.rb
+++ b/spec/identifiers/doi_spec.rb
@@ -37,9 +37,21 @@ RSpec.describe Identifiers::DOI do
     expect(described_class.extract(str)).to be_empty
   end
 
-  it 'retains potentially valid trailing punctuation' do
+  it 'retains closing parentheses that are part of the DOI' do
     str = 'This is an example of DOI: 10.1130/2013.2502(04)'
 
     expect(described_class.extract(str)).to contain_exactly('10.1130/2013.2502(04)')
+  end
+
+  it 'discards trailing punctuation' do
+    str = 'This is an example of DOI: 10.1130/2013.2502.'
+
+    expect(described_class.extract(str)).to contain_exactly('10.1130/2013.2502')
+  end
+
+  it 'does not extract a closing parenthesis if not part of the DOI' do
+    str = '(This is an example of DOI: 10.1130/2013.2502)'
+
+    expect(described_class.extract(str)).to contain_exactly('10.1130/2013.2502')
   end
 end

--- a/spec/identifiers/doi_spec.rb
+++ b/spec/identifiers/doi_spec.rb
@@ -7,6 +7,12 @@ RSpec.describe Identifiers::DOI do
     expect(described_class.extract(str)).to contain_exactly('10.1049/el.2013.3006')
   end
 
+  it 'extracts DOIs from anywhere in a string' do
+    str = 'This is an example of DOI - 10.1049/el.2013.3006 - which is entirely valid'
+
+    expect(described_class.extract(str)).to contain_exactly('10.1049/el.2013.3006')
+  end
+
   it 'downcase the DOIs extracted' do
     str = 'This is an example of DOI: 10.1097/01.ASW.0000443266.17665.19'
 
@@ -29,5 +35,11 @@ RSpec.describe Identifiers::DOI do
     str = 'This is not an ISBN-A: 10.978.8898392/NotARealIsbnA'
 
     expect(described_class.extract(str)).to be_empty
+  end
+
+  it 'retains potentially valid trailing punctuation' do
+    str = 'This is an example of DOI: 10.1130/2013.2502(04)'
+
+    expect(described_class.extract(str)).to contain_exactly('10.1130/2013.2502(04)')
   end
 end


### PR DESCRIPTION
During some internal data clean-up work at @altmetric, we discovered DOIs that end with closing parentheses. These were being dropped by our extraction regular expression as we enforce a word boundary (which splits when a word character is followed by a non-word character such as a closing parenthesis).

By removing the strict word boundary, we can now pick up these closing parentheses and filter out any unwanted trailing punctuation in a second pass over the matches.

We do this by explicitly dropping the last character if it is punctuation but _not_ if the DOI ends in a single, balanced parenthetical group of characters.

This means that we can successfully extract valid DOIs such as 10.1002/0471221929.ch26(v) but not invalid ones such as 10.1007/978-3-319-12580-0).