### PR TITLE
Remove trailing punctuation after Wiley DOIs

### DIFF
--- a/lib/identifiers/doi.rb
+++ b/lib/identifiers/doi.rb
@@ -33,11 +33,21 @@ module Identifiers
         .to_s
         .downcase
         .scan(PATTERN)
-        .map { |doi|
-          next doi if doi =~ VALID_ENDING
+        .map { |doi| strip_punctuation(doi) }
+        .compact
+    end
 
-          doi.sub(/\p{Punct}+\z/, '')
-        }
+    def self.extract_one(str)
+      match = str.to_s.downcase[PATTERN]
+      return unless match
+
+      strip_punctuation(match)
+    end
+
+    def self.strip_punctuation(doi)
+      return doi if doi =~ VALID_ENDING
+
+      extract_one(doi.sub(/\p{Punct}\z/, ''))
     end
   end
 end

--- a/spec/identifiers/doi_spec.rb
+++ b/spec/identifiers/doi_spec.rb
@@ -65,8 +65,8 @@ RSpec.describe Identifiers::DOI do
     expect(described_class.extract(str)).to contain_exactly('10.1130/2013.2502')
   end
 
-  it 'extracts particularly exotic DOIs' do
-    str = 'This is an example of an exotic DOI: 10.1002/(SICI)1096-8644(199601)99:1<135::AID-AJPA8>3.0.CO;2-#'
+  it 'extracts old Wiley DOIs' do
+    str = 'This is an example of an old Wiley DOI: 10.1002/(SICI)1096-8644(199601)99:1<135::AID-AJPA8>3.0.CO;2-#'
 
     expect(described_class.extract(str)).to contain_exactly('10.1002/(sici)1096-8644(199601)99:1<135::aid-ajpa8>3.0.co;2-#')
   end
@@ -75,5 +75,39 @@ RSpec.describe Identifiers::DOI do
     str = '(This is an example of a DOI: 10.1130/2013.2502)'
 
     expect(described_class.extract(str)).to contain_exactly('10.1130/2013.2502')
+  end
+
+  it 'discards trailing punctuation from old Wiley DOIs' do
+    str = 'This is an example of an old Wiley DOI: 10.1002/(SICI)1096-8644(199601)99:1<135::AID-AJPA8>3.0.CO;2-#",'
+
+    expect(described_class.extract(str)).to contain_exactly('10.1002/(sici)1096-8644(199601)99:1<135::aid-ajpa8>3.0.co;2-#')
+  end
+
+  it 'discards trailing punctuation after balanced parentheses' do
+    str = 'This is an example of a DOI: This is an example of a DOI: 10.1130/2013.2502(04).'
+
+    expect(described_class.extract(str)).to contain_exactly('10.1130/2013.2502(04)')
+  end
+
+  it 'discards contiguous trailing punctuation after balanced parentheses' do
+    str = 'This is an example of a DOI: This is an example of a DOI: 10.1130/2013.2502(04).",'
+
+    expect(described_class.extract(str)).to contain_exactly('10.1130/2013.2502(04)')
+  end
+
+  it 'discards trailing Unicode punctuation after balanced parentheses' do
+    str = 'This is an example of a DOI: 10.1130/2013.2502(04)…",'
+
+    expect(described_class.extract(str)).to contain_exactly('10.1130/2013.2502(04)')
+  end
+
+  it 'discards contiguous trailing punctuation after unbalanced parentheses' do
+    str = '(This is an example of a DOI: 10.1130/2013.2502).",'
+
+    expect(described_class.extract(str)).to contain_exactly('10.1130/2013.2502')
+  end
+
+  it 'does not extract DOIs with purely punctuation suffixes' do
+    expect(described_class.extract('10.1130/!).",')).to be_empty
   end
 end


### PR DESCRIPTION
While our new logic supported valid DOIs ended in punctuation and removed superfluous punctuation from otherwise valid DOIs, it didn't support both at the same time: a valid, old Wiley DOI ending in # couldn't be extracted if it also had trailing punctuation.

This fixes that by recursively stripping trailing punctuation one character at a time and re-extracting until a valid DOI is found.