### PR TITLE
Support ISBNs separated by Unicode spaces & dashes

### DIFF
--- a/lib/identifiers/isbn.rb
+++ b/lib/identifiers/isbn.rb
@@ -13,11 +13,11 @@ module Identifiers
     end
 
     def self.extract_thirteen_digit_isbns(str)
-      str.gsub(/(?<=\d)[- ](?=\d)/, '').scan(REGEX_13).select { |isbn| valid_isbn_13?(isbn) }
+      str.gsub(/(?<=\d)[\p{Pd}\p{Zs}](?=\d)/, '').scan(REGEX_13).select { |isbn| valid_isbn_13?(isbn) }
     end
 
     def self.extract_ten_digit_isbns(str)
-      str.gsub(/(?<=\d)[- ](?=[\dX])/i, '').scan(REGEX_10).select { |isbn| valid_isbn_10?(isbn) }.map { |isbn|
+      str.gsub(/(?<=\d)[\p{Pd}\p{Zs}](?=[\dX])/i, '').scan(REGEX_10).select { |isbn| valid_isbn_10?(isbn) }.map { |isbn|
         isbn.chop!
         isbn.prepend('978')
         isbn << isbn_13_check_digit(isbn).to_s

--- a/spec/identifiers/isbn_spec.rb
+++ b/spec/identifiers/isbn_spec.rb
@@ -15,8 +15,16 @@ RSpec.describe Identifiers::ISBN do
     expect(described_class.extract('ISBN: 978-0-80-506909-9')).to contain_exactly('9780805069099')
   end
 
+  it 'extracts ISBNs with Unicode dashes' do
+    expect(described_class.extract('ISBN: 978–0–80–506909–9')).to contain_exactly('9780805069099')
+  end
+
   it 'extracts ISBNs with spaces' do
     expect(described_class.extract('ISBN: 978 0 80 506909 9')).to contain_exactly('9780805069099')
+  end
+
+  it 'extracts ISBNs with Unicode spaces' do
+    expect(described_class.extract('ISBN: 978 0 80 506909 9')).to contain_exactly('9780805069099')
   end
 
   it 'extracts ISBN-13s from ISBN-As' do
@@ -33,12 +41,20 @@ RSpec.describe Identifiers::ISBN do
     expect(described_class.extract(str)).to contain_exactly('9780805069099', '9782759402694')
   end
 
+  it 'normalizes 10-digit ISBNs with Unicode dashes' do
+    expect(described_class.extract('0–8050–6909–7')).to contain_exactly('9780805069099')
+  end
+
   it 'normalizes 10-digit ISBNs with a check digit of 10' do
     expect(described_class.extract('4423272350')).to contain_exactly('9784423272350')
   end
 
   it 'normalizes 10-digit ISBNs with spaces' do
     expect(described_class.extract('0 8050 6909 7')).to contain_exactly('9780805069099')
+  end
+
+  it 'normalizes 10-digit ISBNs with Unicode spaces' do
+    expect(described_class.extract('0 8050 6909 7')).to contain_exactly('9780805069099')
   end
 
   it 'normalizes 10-digit ISBNs with spaces and a check digit of X' do


### PR DESCRIPTION
Use Unicode character properties to extract ISBNs that have their digits separated by any Unicode space or dash. While we typically rely on the caller to clean up their data, the ISBN format permits such use of whitespace and dash punctuation so we should be permissive in what we accept.