### PR TITLE
Support Unicode whitespace as a separator

### DIFF
--- a/lib/identifiers/arxiv_id.rb
+++ b/lib/identifiers/arxiv_id.rb
@@ -6,13 +6,13 @@ module Identifiers
 
     def self.extract_post_2007_arxiv_ids(str)
       str
-        .scan(%r{(?<=^|\s|/)(?:arXiv:)?\d{4}\.\d{4,5}(?:v\d+)?(?=$|\s)}i)
+        .scan(%r{(?<=^|[[:space:]/])(?:arXiv:)?\d{4}\.\d{4,5}(?:v\d+)?(?=$|[[:space:]])}i)
         .map { |arxiv_id| arxiv_id.sub(/\AarXiv:/i, '') }
     end
 
     def self.extract_pre_2007_arxiv_ids(str)
       str
-        .scan(%r{(?<=^|\s|/)(?:arXiv:)?[a-z-]+(?:\.[A-Z]{2})?/\d{2}(?:0[1-9]|1[012])\d{3}(?:v\d+)?(?=$|\s)}i)
+        .scan(%r{(?<=^|[[:space:]/])(?:arXiv:)?[a-z-]+(?:\.[A-Z]{2})?/\d{2}(?:0[1-9]|1[012])\d{3}(?:v\d+)?(?=$|[[:space:]])}i)
         .map { |arxiv_id| arxiv_id.sub(/\AarXiv:/i, '') }
     end
   end

--- a/lib/identifiers/doi.rb
+++ b/lib/identifiers/doi.rb
@@ -12,18 +12,18 @@ module Identifiers
         \d{1,7}  # ISBN title enumerator and check digit
         |
         # DOI
-        \d{4,9} # Registrant code
-        /       # Prefix/suffix divider
-        \S+     # DOI suffix
+        \d{4,9}       # Registrant code
+        /             # Prefix/suffix divider
+        [^[:space:]]+ # DOI suffix
       )
     }x
     VALID_ENDING = /
       (?:
-        \p{^Punct}  # Non-punctuation character
+        \p{^Punct} # Non-punctuation character
         |
-        \(.+\)      # Balanced parentheses
+        \(.+\)     # Balanced parentheses
         |
-        2-\#        # Early Wiley DOI suffix
+        2-\#       # Early Wiley DOI suffix
       )
       \z
     /x

--- a/lib/identifiers/handle.rb
+++ b/lib/identifiers/handle.rb
@@ -1,7 +1,7 @@
 module Identifiers
   class Handle
     def self.extract(str)
-      str.scan(%r{\b[0-9.]+/\S+\b}i)
+      str.scan(%r{\b[0-9.]+/[^[:space:]]+\b}i)
     end
   end
 end

--- a/lib/identifiers/pubmed_id.rb
+++ b/lib/identifiers/pubmed_id.rb
@@ -2,7 +2,7 @@ module Identifiers
   class PubmedId
     def self.extract(str)
       str
-        .scan(/(?<=^|\s)0*(?!0)(\d+)(?=$|\s)/)
+        .scan(/(?<=^|[[:space:]])0*(?!0)(\d+)(?=$|[[:space:]])/)
         .flatten
     end
   end

--- a/lib/identifiers/repec_id.rb
+++ b/lib/identifiers/repec_id.rb
@@ -1,7 +1,7 @@
 module Identifiers
   class RepecId
     def self.extract(str)
-      str.scan(/\brepec:\S+\b/i).map { |repec| "RePEc:#{repec.split(':', 2).last}" }
+      str.scan(/\brepec:[^[:space:]]+\b/i).map { |repec| "RePEc:#{repec.split(':', 2).last}" }
     end
   end
 end

--- a/spec/identifiers/arxiv_id_spec.rb
+++ b/spec/identifiers/arxiv_id_spec.rb
@@ -21,5 +21,13 @@ RSpec.describe Identifiers::ArxivId do
     it 'does not extract IDs from DOIs that contain a valid arXiv ID' do
       expect(described_class.extract('10.2310/7290.2014.00033')).to be_empty
     end
+
+    it 'extracts a post 2007 arXiv ID surrounded by Unicode whitespace' do
+      expect(described_class.extract('Example: arXiv:0706.0001 ')).to contain_exactly('0706.0001')
+    end
+
+    it 'extracts a pre 2007 arXiv ID surrounded by Unicode whitespace' do
+      expect(described_class.extract('Example: math.GT/0309136 ')).to contain_exactly('math.GT/0309136')
+    end
   end
 end

--- a/spec/identifiers/doi_spec.rb
+++ b/spec/identifiers/doi_spec.rb
@@ -110,4 +110,12 @@ RSpec.describe Identifiers::DOI do
   it 'does not extract DOIs with purely punctuation suffixes' do
     expect(described_class.extract('10.1130/!).",')).to be_empty
   end
+
+  it 'extracts DOIs with emoji in them' do
+    expect(described_class.extract('10.1234/🐔💩123🐔🐔🐔123')).to contain_exactly('10.1234/🐔💩123🐔🐔🐔123')
+  end
+
+  it 'extracts DOIs separated by Unicode whitespace' do
+    expect(described_class.extract('10.1234/foo  10.1234/bar')).to contain_exactly('10.1234/foo', '10.1234/bar')
+  end
 end

--- a/spec/identifiers/handle_spec.rb
+++ b/spec/identifiers/handle_spec.rb
@@ -12,4 +12,10 @@ RSpec.describe Identifiers::Handle do
 
     expect(described_class.extract(str)).to contain_exactly('2117/83545it.ly/1UtXnTW')
   end
+
+  it 'extracts Handles separated by Unicode whitespace' do
+    str = '10149/596901 10251/79612'
+
+    expect(described_class.extract(str)).to contain_exactly('10149/596901', '10251/79612')
+  end
 end

--- a/spec/identifiers/pubmed_id_spec.rb
+++ b/spec/identifiers/pubmed_id_spec.rb
@@ -18,4 +18,8 @@ RSpec.describe Identifiers::PubmedId do
   it 'does not consider 0 as a valid Pubmed ID' do
     expect(described_class.extract("00000000")).to be_empty
   end
+
+  it 'extracts PubMed IDs separated by Unicode whitespace' do
+    expect(described_class.extract('123 456')).to contain_exactly('123', '456')
+  end
 end

--- a/spec/identifiers/repec_id_spec.rb
+++ b/spec/identifiers/repec_id_spec.rb
@@ -12,4 +12,10 @@ RSpec.describe Identifiers::RepecId do
 
     expect(described_class.extract(str)).to contain_exactly('RePEc:wbk:wbpubs:2266', 'RePEc:inn:wpaper:2016-03')
   end
+
+  it 'extracts RePEc IDs separated by Unicode whitespace' do
+    str = "RePEc:wbk:wbpubs:2266 RePEc:inn:wpaper:2016-03"
+
+    expect(described_class.extract(str)).to contain_exactly('RePEc:wbk:wbpubs:2266', 'RePEc:inn:wpaper:2016-03')
+  end
 end


### PR DESCRIPTION
Wherever we expect whitespace, use the POSIX bracket expression for whitespace instead of the whitespace metacharacter as it supports non-ASCII characters.