### PR TITLE
Consistantly support nil or non-string values

### DIFF
--- a/lib/identifiers/ads_bibcode.rb
+++ b/lib/identifiers/ads_bibcode.rb
@@ -1,7 +1,7 @@
 module Identifiers
   class AdsBibcode
     def self.extract(str)
-      str.scan(/\b\d{4}[a-z][0-9a-z&.]{14}\b/i)
+      str.to_s.scan(/\b\d{4}[a-z][0-9a-z&.]{14}\b/i)
     end
   end
 end

--- a/lib/identifiers/arxiv_id.rb
+++ b/lib/identifiers/arxiv_id.rb
@@ -6,12 +6,14 @@ module Identifiers
 
     def self.extract_post_2007_arxiv_ids(str)
       str
+        .to_s
         .scan(%r{(?<=^|[[:space:]/])(?:arXiv:)?\d{4}\.\d{4,5}(?:v\d+)?(?=$|[[:space:]])}i)
         .map { |arxiv_id| arxiv_id.sub(/\AarXiv:/i, '') }
     end
 
     def self.extract_pre_2007_arxiv_ids(str)
       str
+        .to_s
         .scan(%r{(?<=^|[[:space:]/])(?:arXiv:)?[a-z-]+(?:\.[A-Z]{2})?/\d{2}(?:0[1-9]|1[012])\d{3}(?:v\d+)?(?=$|[[:space:]])}i)
         .map { |arxiv_id| arxiv_id.sub(/\AarXiv:/i, '') }
     end

--- a/lib/identifiers/handle.rb
+++ b/lib/identifiers/handle.rb
@@ -1,7 +1,7 @@
 module Identifiers
   class Handle
     def self.extract(str)
-      str.scan(%r{\b[0-9.]+/[^[:space:]]+\b}i)
+      str.to_s.scan(%r{\b[0-9.]+/[^[:space:]]+\b}i)
     end
   end
 end

--- a/lib/identifiers/isbn.rb
+++ b/lib/identifiers/isbn.rb
@@ -9,21 +9,32 @@ module Identifiers
     end
 
     def self.extract_isbn_as(str)
-      extract_thirteen_digit_isbns(str.scan(REGEX_A).join("\n").tr('/.', ''))
+      isbn_as = str.to_s.scan(REGEX_A).join("\n").tr('/.', '')
+
+      extract_thirteen_digit_isbns(isbn_as)
     end
 
     def self.extract_thirteen_digit_isbns(str)
-      str.gsub(/(?<=\d)[\p{Pd}\p{Zs}](?=\d)/, '').scan(REGEX_13).select { |isbn| valid_isbn_13?(isbn) }
+      str
+        .to_s
+        .gsub(/(?<=\d)[\p{Pd}\p{Zs}](?=\d)/, '')
+        .scan(REGEX_13)
+        .select { |isbn| valid_isbn_13?(isbn) }
     end
 
     def self.extract_ten_digit_isbns(str)
-      str.gsub(/(?<=\d)[\p{Pd}\p{Zs}](?=[\dX])/i, '').scan(REGEX_10).select { |isbn| valid_isbn_10?(isbn) }.map { |isbn|
-        isbn.chop!
-        isbn.prepend('978')
-        isbn << isbn_13_check_digit(isbn).to_s
+      str
+        .to_s
+        .gsub(/(?<=\d)[\p{Pd}\p{Zs}](?=[\dX])/i, '')
+        .scan(REGEX_10)
+        .select { |isbn| valid_isbn_10?(isbn) }
+        .map { |isbn|
+          isbn.chop!
+          isbn.prepend('978')
+          isbn << isbn_13_check_digit(isbn).to_s
 
-        isbn
-      }
+          isbn
+        }
     end
 
     def self.isbn_13_check_digit(isbn)
@@ -54,7 +65,7 @@ module Identifiers
     end
 
     def self.digits_of(isbn)
-      isbn.each_char.map { |char| char == 'X' ? 10 : Integer(char) }.to_enum
+      isbn.to_s.each_char.map { |char| char == 'X' ? 10 : Integer(char) }.to_enum
     end
   end
 end

--- a/lib/identifiers/national_clinical_trial_id.rb
+++ b/lib/identifiers/national_clinical_trial_id.rb
@@ -1,7 +1,7 @@
 module Identifiers
   class NationalClinicalTrialId
     def self.extract(str)
-      str.scan(/\bNCT\d+\b/i).map(&:upcase)
+      str.to_s.scan(/\bNCT\d+\b/i).map(&:upcase)
     end
   end
 end

--- a/lib/identifiers/orcid.rb
+++ b/lib/identifiers/orcid.rb
@@ -3,7 +3,11 @@ module Identifiers
     REGEX = /\b(?:\d{4}-){3}\d{3}[\dx]\b/i
 
     def self.extract(str)
-      str.scan(REGEX).select { |orcid| valid?(orcid) }.map(&:upcase)
+      str
+        .to_s
+        .scan(REGEX)
+        .select { |orcid| valid?(orcid) }
+        .map(&:upcase)
     end
 
     def self.valid?(str)

--- a/lib/identifiers/pubmed_id.rb
+++ b/lib/identifiers/pubmed_id.rb
@@ -2,6 +2,7 @@ module Identifiers
   class PubmedId
     def self.extract(str)
       str
+        .to_s
         .scan(/(?<=^|[[:space:]])0*(?!0)(\d+)(?=$|[[:space:]])/)
         .flatten
     end

--- a/lib/identifiers/repec_id.rb
+++ b/lib/identifiers/repec_id.rb
@@ -1,7 +1,10 @@
 module Identifiers
   class RepecId
     def self.extract(str)
-      str.scan(/\brepec:[^[:space:]]+\b/i).map { |repec| "RePEc:#{repec.split(':', 2).last}" }
+      str
+        .to_s
+        .scan(/\brepec:[^[:space:]]+\b/i)
+        .map { |repec| "RePEc:#{repec.split(':', 2).last}" }
     end
   end
 end

--- a/spec/identifiers/ads_bibcode_spec.rb
+++ b/spec/identifiers/ads_bibcode_spec.rb
@@ -15,5 +15,9 @@ RSpec.describe Identifiers::AdsBibcode do
     it 'does not extract Bibcodes from DOIs' do
       expect(described_class.extract('10.1097/01.ASW.0000443266.17665.19')).to be_empty
     end
+
+    it 'returns no Bibcode if nothing is given' do
+      expect(described_class.extract(nil)).to be_empty
+    end
   end
 end

--- a/spec/identifiers/arxiv_id_spec.rb
+++ b/spec/identifiers/arxiv_id_spec.rb
@@ -22,6 +22,10 @@ RSpec.describe Identifiers::ArxivId do
       expect(described_class.extract('10.2310/7290.2014.00033')).to be_empty
     end
 
+    it 'extracts nothing from empty arguments' do
+      expect(described_class.extract(nil)).to be_empty
+    end
+
     it 'extracts a post 2007 arXiv ID surrounded by Unicode whitespace' do
       expect(described_class.extract('Example: arXiv:0706.0001 ')).to contain_exactly('0706.0001')
     end

--- a/spec/identifiers/handle_spec.rb
+++ b/spec/identifiers/handle_spec.rb
@@ -18,4 +18,8 @@ RSpec.describe Identifiers::Handle do
 
     expect(described_class.extract(str)).to contain_exactly('10149/596901', '10251/79612')
   end
+
+  it 'extracts nothing from empty arguments' do
+    expect(described_class.extract(nil)).to be_empty
+  end
 end

--- a/spec/identifiers/isbn_spec.rb
+++ b/spec/identifiers/isbn_spec.rb
@@ -5,6 +5,12 @@ RSpec.describe Identifiers::ISBN do
     expect(described_class.extract('ISBN: 9780805069099')).to contain_exactly('9780805069099')
   end
 
+  it 'extracts ISBNs when given as a number' do
+    isbn = 9780805069099
+
+    expect(described_class.extract(isbn)).to contain_exactly('9780805069099')
+  end
+
   it 'normalizes 13-digit ISBNs' do
     str = "978-0-80-506909-9\n978-0-67-187919-8"
 

--- a/spec/identifiers/national_clinical_trial_id_spec.rb
+++ b/spec/identifiers/national_clinical_trial_id_spec.rb
@@ -8,4 +8,8 @@ RSpec.describe Identifiers::NationalClinicalTrialId do
   it 'normalizes NCT IDs' do
     expect(described_class.extract("nct00000106\nnCt00000107")).to contain_exactly('NCT00000106', 'NCT00000107')
   end
+
+  it 'does not match anything with empty arguments' do
+    expect(described_class.extract(nil)).to be_empty
+  end
 end

--- a/spec/identifiers/pubmed_id_spec.rb
+++ b/spec/identifiers/pubmed_id_spec.rb
@@ -22,4 +22,8 @@ RSpec.describe Identifiers::PubmedId do
   it 'extracts PubMed IDs separated by Unicode whitespace' do
     expect(described_class.extract('123 456')).to contain_exactly('123', '456')
   end
+
+  it 'considers Fixnum as potential PubmedIds too' do
+    expect(described_class.extract(123)).to contain_exactly('123')
+  end
 end

--- a/spec/identifiers/repec_id_spec.rb
+++ b/spec/identifiers/repec_id_spec.rb
@@ -18,4 +18,8 @@ RSpec.describe Identifiers::RepecId do
 
     expect(described_class.extract(str)).to contain_exactly('RePEc:wbk:wbpubs:2266', 'RePEc:inn:wpaper:2016-03')
   end
+
+  it 'extracts nothing when given empty arguments' do
+    expect(described_class.extract(nil)).to be_empty
+  end
 end


### PR DESCRIPTION
Fixes issues caused by attempting to extract identifiers on nil, or
other non-string, values.

The precendent here is set by the Identifiers::DOI `extract` method,
which already does this. It's rather handy to have nil values be
supported as it removes the need for guards around this code.