### PR TITLE
Support ISBNs separated by a single space

### DIFF
--- a/lib/identifiers/isbn.rb
+++ b/lib/identifiers/isbn.rb
@@ -1,34 +1,57 @@
 module Identifiers
   class ISBN
-    REGEX_13 = /\b97[89]\d{10}\b/
-    REGEX_10 = /\b\d{9}(?:\d|X)\b/
-    REGEX_A = %r{\b(?<=10\.)97[89]\.\d{2,8}/\d{1,7}\b}
+    ISBN_13_REGEXP = /
+      \b
+      97[89]            # ISBN (GS1) Bookland prefix
+      [\p{Pd}\p{Zs}]?   # Optional hyphenation
+      (?:
+        \d              # Digit
+        [\p{Pd}\p{Zs}]? # Optional hyphenation
+      ){9}
+      \d                # Check digit
+      \b
+    /x
+    ISBN_10_REGEXP = /
+      \b
+      (?:
+        \d              # Digit
+        [\p{Pd}\p{Zs}]? # Optional hyphenation
+      ){9}
+      [\dX]             # Check digit
+      \b
+    /x
+    ISBN_A_REGEXP = %r{
+      \b
+      (?<=10\.) # Directory indicator (always 10)
+      97[89]\.  # ISBN (GS1) Bookland prefix
+      \d{2,8}   # ISBN registration group element and publisher prefix
+      /         # Prefix/suffix divider
+      \d{1,7}   # ISBN title enumerator and check digit
+      \b
+    }x
 
     def self.extract(str)
       extract_isbn_as(str) + extract_thirteen_digit_isbns(str) + extract_ten_digit_isbns(str)
     end
 
     def self.extract_isbn_as(str)
-      isbn_as = str.to_s.scan(REGEX_A).join("\n").tr('/.', '')
-
-      extract_thirteen_digit_isbns(isbn_as)
+      extract_thirteen_digit_isbns(str.to_s.scan(ISBN_A_REGEXP).join("\n").tr('/.', ''))
     end
 
     def self.extract_thirteen_digit_isbns(str)
       str
         .to_s
-        .gsub(/(?<=\d)[\p{Pd}\p{Zs}](?=\d)/, '')
-        .scan(REGEX_13)
+        .scan(ISBN_13_REGEXP)
+        .map { |isbn| isbn.gsub(/[\p{Pd}\p{Zs}]/, '') }
         .select { |isbn| valid_isbn_13?(isbn) }
     end
 
     def self.extract_ten_digit_isbns(str)
       str
         .to_s
-        .gsub(/(?<=\d)[\p{Pd}\p{Zs}](?=[\dX])/i, '')
-        .scan(REGEX_10)
-        .select { |isbn| valid_isbn_10?(isbn) }
-        .map { |isbn|
+        .scan(ISBN_10_REGEXP)
+        .map { |isbn| isbn.gsub(/[\p{Pd}\p{Zs}]/, '') }
+        .select { |isbn| valid_isbn_10?(isbn) }.map { |isbn|
           isbn.chop!
           isbn.prepend('978')
           isbn << isbn_13_check_digit(isbn).to_s
@@ -49,7 +72,7 @@ module Identifiers
     end
 
     def self.valid_isbn_13?(isbn)
-      return false unless isbn =~ REGEX_13
+      return false unless isbn =~ ISBN_13_REGEXP
 
       result = digits_of(isbn).zip([1, 3].cycle).map { |digit, weight| digit * weight }.reduce(:+)
 
@@ -57,7 +80,7 @@ module Identifiers
     end
 
     def self.valid_isbn_10?(isbn)
-      return false unless isbn =~ REGEX_10
+      return false unless isbn =~ ISBN_10_REGEXP
 
       result = digits_of(isbn).with_index.map { |digit, weight| digit * weight.succ }.reduce(:+)
 

--- a/lib/identifiers/orcid.rb
+++ b/lib/identifiers/orcid.rb
@@ -1,11 +1,11 @@
 module Identifiers
   class ORCID
-    REGEX = /\b(?:\d{4}-){3}\d{3}[\dx]\b/i
+    REGEXP = /\b(?:\d{4}-){3}\d{3}[\dx]\b/i
 
     def self.extract(str)
       str
         .to_s
-        .scan(REGEX)
+        .scan(REGEXP)
         .select { |orcid| valid?(orcid) }
         .map(&:upcase)
     end
@@ -18,7 +18,7 @@ module Identifiers
     end
 
     def self.calculate_digit(str)
-      return unless str =~ REGEX
+      return unless str =~ REGEXP
 
       base_digits = str.chop.tr('-', '')
       total = 0

--- a/spec/identifiers/isbn_spec.rb
+++ b/spec/identifiers/isbn_spec.rb
@@ -17,6 +17,12 @@ RSpec.describe Identifiers::ISBN do
     expect(described_class.extract(str)).to contain_exactly('9780805069099', '9780671879198')
   end
 
+  it 'extracts multiple ISBN-13s separated by a space' do
+    str = '978-0-80-506909-9 978-0-67-187919-8'
+
+    expect(described_class.extract(str)).to contain_exactly('9780805069099', '9780671879198')
+  end
+
   it 'extracts ISBNs with hyphens' do
     expect(described_class.extract('ISBN: 978-0-80-506909-9')).to contain_exactly('9780805069099')
   end
@@ -43,6 +49,12 @@ RSpec.describe Identifiers::ISBN do
 
   it 'normalizes 10-digit ISBNs' do
     str = "0-8050-6909-7 \n 2-7594-0269-X"
+
+    expect(described_class.extract(str)).to contain_exactly('9780805069099', '9782759402694')
+  end
+
+  it 'extracts multiple 10-digit ISBNs separated by a space' do
+    str = '0-8050-6909-7 2-7594-0269-X'
 
     expect(described_class.extract(str)).to contain_exactly('9780805069099', '9782759402694')
   end


### PR DESCRIPTION
While the hyphenation of ISBNs is complicated due to the variable length of each composite part, we can be more restrictive about where spaces and hyphens can appear in a valid ISBN: between each digit (and after the Bookland country code).

This means we can first try to extract candidate ISBNs (including any spaces and hyphens) and then remove them before validating their check digits.

This fixes a bug where multiple ISBNs separated by spaces would be concatenated together which would mean they could no longer be extracted.