### PR TITLE
Do not extract ISBN-10s from hyphenated ISBN-13s

### DIFF
--- a/lib/identifiers/isbn.rb
+++ b/lib/identifiers/isbn.rb
@@ -13,6 +13,7 @@ module Identifiers
     /x
     ISBN_10_REGEXP = /
       \b
+      (?<!\p{Pd})       # Do not accidentally match a hyphenated ISBN-13
       (?:
         \d              # Digit
         [\p{Pd}\p{Zs}]? # Optional hyphenation

--- a/lib/identifiers/isbn.rb
+++ b/lib/identifiers/isbn.rb
@@ -12,8 +12,11 @@ module Identifiers
       \b
     /x
     ISBN_10_REGEXP = /
+      (?<!              # Do not accidentally match a hyphenated ISBN-13
+        97[89]
+        [\p{Pd}\p{Zs}]
+      )
       \b
-      (?<!\p{Pd})       # Do not accidentally match a hyphenated ISBN-13
       (?:
         \d              # Digit
         [\p{Pd}\p{Zs}]? # Optional hyphenation

--- a/spec/identifiers/isbn_spec.rb
+++ b/spec/identifiers/isbn_spec.rb
@@ -90,4 +90,8 @@ RSpec.describe Identifiers::ISBN do
   it 'does not extract ISBN-10s from hyphenated ISBN-13s' do
     expect(described_class.extract('978-0-309-57079-4')).to contain_exactly('9780309570794')
   end
+
+  it 'does not extract ISBN-10s from space-separated ISBN-13s' do
+    expect(described_class.extract('978 0 309 57079 4')).to contain_exactly('9780309570794')
+  end
 end

--- a/spec/identifiers/isbn_spec.rb
+++ b/spec/identifiers/isbn_spec.rb
@@ -86,4 +86,8 @@ RSpec.describe Identifiers::ISBN do
   it 'does not extract invalid 10-digit ISBNs' do
     expect(described_class.extract('3319217280')).to be_empty
   end
+
+  it 'does not extract ISBN-10s from hyphenated ISBN-13s' do
+    expect(described_class.extract('978-0-309-57079-4')).to contain_exactly('9780309570794')
+  end
 end


### PR DESCRIPTION
The improved support for hyphenated ISBNs has accidentally started extracting ISBN-10s from ISBN-13s when they are substrings of one another (typically the check digit changes but there are some ISBNs with check digits that do not change when converting).

As this means we'll start returning duplicate ISBNs for any ISBN that has this property, explicitly prevent extracting ISBN-10s from a longer hyphenated string of digits.