### PR TITLE
Support extracting PubMed IDs from PubMed URL

### DIFF
--- a/lib/identifiers/pubmed_id.rb
+++ b/lib/identifiers/pubmed_id.rb
@@ -1,7 +1,7 @@
 module Identifiers
   class PubmedId
     ZERO_PADDED_NUMBER = %r{(?<=^|[[:space:]])0*(?!0)(\d+)(?=$|[[:space:]])}
-    PUBMED_URL = %r{https?://(?:www\.)?ncbi\.nlm\.nih\.gov/pubmed/0*(\d+)}i
+    PUBMED_URL = %r{https?://(?:www\.)?ncbi\.nlm\.nih\.gov/(?:m/)?pubmed/0*(\d+)}i
 
     def self.extract(str)
       str = str.to_s

--- a/lib/identifiers/pubmed_id.rb
+++ b/lib/identifiers/pubmed_id.rb
@@ -1,9 +1,11 @@
 module Identifiers
   class PubmedId
+    ZERO_PADDED_NUMBER = %r{(?<=^|[[:space:]])0*(?!0)(\d+)(?=$|[[:space:]])}
+    PUBMED_URL = %r{https?://(?:www\.)?ncbi\.nlm\.nih\.gov/pubmed/0*(\d+)}i
+
     def self.extract(str)
       str = str.to_s
-      str.scan(/(?<=^|[[:space:]])0*(?!0)(\d+)(?=$|[[:space:]])/).flatten |
-        str.scan(%r{https?://(?:www\.)?ncbi.nlm.nih.gov/pubmed/(\d+)}).flatten
+      str.scan(ZERO_PADDED_NUMBER).flatten | str.scan(PUBMED_URL).flatten
     end
   end
 end

--- a/lib/identifiers/pubmed_id.rb
+++ b/lib/identifiers/pubmed_id.rb
@@ -1,40 +1,9 @@
 module Identifiers
   class PubmedId
     def self.extract(str)
-      new(str).extract
-    end
-
-    attr_reader :pubmed_candidate
-    private :pubmed_candidate
-
-    URL_REGEX = %r{^https?://(?:www\.)?ncbi.nlm.nih.gov/pubmed/}
-
-    def initialize(pubmed_candidate)
-      @pubmed_candidate = pubmed_candidate.to_s
-    end
-
-    def extract
-      extract_from_number | extract_from_pubmed_url
-    end
-
-    private
-
-    def extract_from_pubmed_url
-      return [] unless contains_pubmed_id?
-
-      Array(pubmed_id_from_url)
-    end
-
-    def contains_pubmed_id?
-      pubmed_candidate =~ URL_REGEX
-    end
-
-    def pubmed_id_from_url
-      pubmed_candidate.sub(URL_REGEX, '')
-    end
-
-    def extract_from_number
-      pubmed_candidate.scan(/(?<=^|[[:space:]])0*(?!0)(\d+)(?=$|[[:space:]])/).flatten
+      str = str.to_s
+      str.scan(/(?<=^|[[:space:]])0*(?!0)(\d+)(?=$|[[:space:]])/).flatten |
+        str.scan(%r{https?://(?:www\.)?ncbi.nlm.nih.gov/pubmed/(\d+)}).flatten
     end
   end
 end

--- a/lib/identifiers/pubmed_id.rb
+++ b/lib/identifiers/pubmed_id.rb
@@ -1,7 +1,40 @@
 module Identifiers
   class PubmedId
     def self.extract(str)
-      str.to_s.scan(/(?<=^|[[:space:]])0*(?!0)(\d+)(?=$|[[:space:]])/).flatten
+      new(str).extract
+    end
+
+    attr_reader :pubmed_candidate
+    private :pubmed_candidate
+
+    URL_REGEX = %r{^https?://(?:www\.)?ncbi.nlm.nih.gov/pubmed/}
+
+    def initialize(pubmed_candidate)
+      @pubmed_candidate = pubmed_candidate.to_s
+    end
+
+    def extract
+      extract_from_number | extract_from_pubmed_url
+    end
+
+    private
+
+    def extract_from_pubmed_url
+      return [] unless contains_pubmed_id?
+
+      Array(pubmed_id_from_url)
+    end
+
+    def contains_pubmed_id?
+      pubmed_candidate =~ URL_REGEX
+    end
+
+    def pubmed_id_from_url
+      pubmed_candidate.sub(URL_REGEX, '')
+    end
+
+    def extract_from_number
+      pubmed_candidate.scan(/(?<=^|[[:space:]])0*(?!0)(\d+)(?=$|[[:space:]])/).flatten
     end
   end
 end

--- a/spec/identifiers/pubmed_id_spec.rb
+++ b/spec/identifiers/pubmed_id_spec.rb
@@ -5,28 +5,46 @@ RSpec.describe Identifiers::PubmedId do
     expect(described_class.extract("123\n456")).to contain_exactly('123', '456')
   end
 
-  it 'extracts PubMed IDs from a PubMed url with www' do
-    url = "http://www.ncbi.nlm.nih.gov/pubmed/123456"
+  it 'extracts PubMed IDs from a PubMed URL with www' do
+    url = 'http://www.ncbi.nlm.nih.gov/pubmed/123456'
 
-    expect(described_class.extract(url)).to contain_exactly("123456")
+    expect(described_class.extract(url)).to contain_exactly('123456')
   end
 
-  it 'extracts PubMed IDs from a PubMed url with www and https' do
-    url = "https://www.ncbi.nlm.nih.gov/pubmed/123456"
+  it 'extracts PubMed IDs from a PubMed URL with www and https' do
+    url = 'https://www.ncbi.nlm.nih.gov/pubmed/123456'
 
-    expect(described_class.extract(url)).to contain_exactly("123456")
+    expect(described_class.extract(url)).to contain_exactly('123456')
   end
 
-  it 'extracts PubMed IDs from a PubMed url without www' do
-    url = "http://ncbi.nlm.nih.gov/pubmed/123456"
+  it 'extracts PubMed IDs from a PubMed URL without www' do
+    url = 'http://ncbi.nlm.nih.gov/pubmed/123456'
 
-    expect(described_class.extract(url)).to contain_exactly("123456")
+    expect(described_class.extract(url)).to contain_exactly('123456')
   end
 
-  it 'extracts PubMed IDs from a PubMed url without www but with https' do
-    url = "https://ncbi.nlm.nih.gov/pubmed/123456"
+  it 'extracts PubMed IDs from a PubMed URL without www but with https' do
+    url = 'https://ncbi.nlm.nih.gov/pubmed/123456'
 
-    expect(described_class.extract(url)).to contain_exactly("123456")
+    expect(described_class.extract(url)).to contain_exactly('123456')
+  end
+
+  it 'extracts PubMed IDs from a PubMed URL with hash parameters' do
+    url = 'https://www.ncbi.nlm.nih.gov/pubmed/123456#cm6191871_69589'
+
+    expect(described_class.extract(url)).to contain_exactly('123456')
+  end
+
+  it 'extracts PubMed IDs from a PubMed URL with query parameters' do
+    url = 'https://www.ncbi.nlm.nih.gov/pubmed/123456?hi=hello&goodbye=bye'
+
+    expect(described_class.extract(url)).to contain_exactly('123456')
+  end
+
+  it 'extracts both number and URLs PubMed IDs' do
+    url = 'PubMed ID: 112233 another: https://www.ncbi.nlm.nih.gov/pubmed/123456'
+
+    expect(described_class.extract(url)).to contain_exactly('112233', '123456')
   end
 
   it 'does not return outputs with PubMed IDs in DOIs' do
@@ -39,15 +57,15 @@ RSpec.describe Identifiers::PubmedId do
     expect(described_class.extract("0000010203\n000456000")).to contain_exactly('10203', '456000')
   end
 
-  it 'does not consider 0 as a valid Pubmed ID' do
-    expect(described_class.extract("00000000")).to be_empty
+  it 'does not consider 0 as a valid PubMed ID' do
+    expect(described_class.extract('00000000')).to be_empty
   end
 
   it 'extracts PubMed IDs separated by Unicode whitespace' do
     expect(described_class.extract('123 456')).to contain_exactly('123', '456')
   end
 
-  it 'considers Fixnum as potential PubmedIds too' do
+  it 'considers Fixnum as potential PubMed IDs too' do
     expect(described_class.extract(123)).to contain_exactly('123')
   end
 end

--- a/spec/identifiers/pubmed_id_spec.rb
+++ b/spec/identifiers/pubmed_id_spec.rb
@@ -29,6 +29,12 @@ RSpec.describe Identifiers::PubmedId do
     expect(described_class.extract(url)).to contain_exactly('123456')
   end
 
+  it 'extracts PubMed IDs from a PubMed mobile URL' do
+    url = 'https://www.ncbi.nlm.nih.gov/m/pubmed/123456'
+
+    expect(described_class.extract(url)).to contain_exactly('123456')
+  end
+
   it 'extracts PubMed IDs from a PubMed URL with hash parameters' do
     url = 'https://www.ncbi.nlm.nih.gov/pubmed/123456#cm6191871_69589'
 

--- a/spec/identifiers/pubmed_id_spec.rb
+++ b/spec/identifiers/pubmed_id_spec.rb
@@ -41,6 +41,12 @@ RSpec.describe Identifiers::PubmedId do
     expect(described_class.extract(url)).to contain_exactly('123456')
   end
 
+  it 'extracts zero leading PubMed IDs from a PubMed URL with query parameters' do
+    url = 'https://www.ncbi.nlm.nih.gov/pubmed/00123456?hi=hello&goodbye=bye'
+
+    expect(described_class.extract(url)).to contain_exactly('123456')
+  end
+
   it 'extracts both number and URLs PubMed IDs' do
     url = 'PubMed ID: 112233 another: https://www.ncbi.nlm.nih.gov/pubmed/123456'
 

--- a/spec/identifiers/pubmed_id_spec.rb
+++ b/spec/identifiers/pubmed_id_spec.rb
@@ -5,6 +5,30 @@ RSpec.describe Identifiers::PubmedId do
     expect(described_class.extract("123\n456")).to contain_exactly('123', '456')
   end
 
+  it 'extracts PubMed IDs from a PubMed url with www' do
+    url = "http://www.ncbi.nlm.nih.gov/pubmed/123456"
+
+    expect(described_class.extract(url)).to contain_exactly("123456")
+  end
+
+  it 'extracts PubMed IDs from a PubMed url with www and https' do
+    url = "https://www.ncbi.nlm.nih.gov/pubmed/123456"
+
+    expect(described_class.extract(url)).to contain_exactly("123456")
+  end
+
+  it 'extracts PubMed IDs from a PubMed url without www' do
+    url = "http://ncbi.nlm.nih.gov/pubmed/123456"
+
+    expect(described_class.extract(url)).to contain_exactly("123456")
+  end
+
+  it 'extracts PubMed IDs from a PubMed url without www but with https' do
+    url = "https://ncbi.nlm.nih.gov/pubmed/123456"
+
+    expect(described_class.extract(url)).to contain_exactly("123456")
+  end
+
   it 'does not return outputs with PubMed IDs in DOIs' do
     str = "10.1038/nplants.2015.3\n10.1126/science.286.5445.1679e"
 


### PR DESCRIPTION
Why:

We were only extracting PubMed IDs if they were surrounded by spaces.
This was to reduce the number of false positives (extracting random numbers from DOIs for example).
The side effect of that change was that we would miss totally valid PubMed IDs coming from PubMed URLs.

This change addresses the need by:

This adds a separate extraction logic for extracting PubMed IDs from PubMed URLs.

Fixes #19 