### PR TITLE
Support URIs with PubMed schemes

### DIFF
--- a/lib/identifiers/pubmed_id.rb
+++ b/lib/identifiers/pubmed_id.rb
@@ -1,7 +1,7 @@
 module Identifiers
   class PubmedId
     ZERO_PADDED_NUMBER = %r{(?<=^|[[:space:]])0*(?!0)(\d+)(?=$|[[:space:]])}
-    PUBMED_URL = %r{https?://(?:www\.)?ncbi\.nlm\.nih\.gov/(?:m/)?pubmed/0*(\d+)}i
+    PUBMED_URL = %r{(?:https?://(?:www\.)?ncbi\.nlm\.nih\.gov/(?:m/)?pubmed/|pmid:|info:pmid/)0*(\d+)}i
 
     def self.extract(str)
       str = str.to_s

--- a/spec/identifiers/pubmed_id_spec.rb
+++ b/spec/identifiers/pubmed_id_spec.rb
@@ -80,4 +80,20 @@ RSpec.describe Identifiers::PubmedId do
   it 'considers Fixnum as potential PubMed IDs too' do
     expect(described_class.extract(123)).to contain_exactly('123')
   end
+
+  it 'extracts PubMed IDs with pmid scheme' do
+    expect(described_class.extract('pmid:123')).to contain_exactly('123')
+  end
+
+  it 'strips leading zeroes from pmid scheme' do
+    expect(described_class.extract('pmid:000123')).to contain_exactly('123')
+  end
+
+  it 'extracts PubMed IDs with info pmid scheme' do
+    expect(described_class.extract('info:pmid/123')).to contain_exactly('123')
+  end
+
+  it 'strips leading zeroes from info pmid scheme' do
+    expect(described_class.extract('info:pmid/000123')).to contain_exactly('123')
+  end
 end


### PR DESCRIPTION
Add support for extracting PubMed IDs out of URIs using the pmid or PubMed info scheme.

Based on https://github.com/altmetric/php-identifiers/pull/15/commits/226173a6ed4d41d8d07a40a5f329be027c83cbcc