### PR TITLE
Prevent stack overflow when extracting DOIs

### DIFF
--- a/lib/identifiers/doi.rb
+++ b/lib/identifiers/doi.rb
@@ -29,20 +29,15 @@ module Identifiers
     /x
 
     def self.extract(str)
-      str.to_s.downcase.scan(REGEXP).map { |doi| strip_punctuation(doi) }.compact
+      str.to_s.downcase.scan(REGEXP).map { |doi| extract_one(doi) }.compact
     end
 
     def self.extract_one(str)
-      match = str.to_s.downcase[REGEXP]
-      return unless match
+      while (match = str.to_s.downcase[REGEXP])
+        break match if match =~ VALID_ENDING
 
-      strip_punctuation(match)
-    end
-
-    def self.strip_punctuation(doi)
-      return doi if doi =~ VALID_ENDING
-
-      extract_one(doi.sub(/\p{Punct}\z/, ''))
+        str = match.sub(/\p{Punct}\z/, '')
+      end
     end
   end
 end

--- a/spec/identifiers/doi_spec.rb
+++ b/spec/identifiers/doi_spec.rb
@@ -107,6 +107,12 @@ RSpec.describe Identifiers::DOI do
     expect(described_class.extract(str)).to contain_exactly('10.1130/2013.2502')
   end
 
+  it 'does not overflow when given lots of trailing punctuation' do
+    str = '10.1130/2013.2502' + ('.' * 10000)
+
+    expect(described_class.extract(str)).to contain_exactly('10.1130/2013.2502')
+  end
+
   it 'does not extract DOIs with purely punctuation suffixes' do
     expect(described_class.extract('10.1130/!).",')).to be_empty
   end


### PR DESCRIPTION
As Ruby doesn't implement tail call optimisation by default, it's possible for a DOI with lots of trailing punctuation to cause a stack overflow due to our recursive implementation.

Replace the recursion with an iterative approach instead.