### PR TITLE
Only extract ISBNs with consistent hyphenation

### DIFF
--- a/lib/identifiers/isbn.rb
+++ b/lib/identifiers/isbn.rb
@@ -2,13 +2,15 @@ module Identifiers
   class ISBN
     ISBN_13_REGEXP = /
       \b
-      97[89]            # ISBN (GS1) Bookland prefix
-      [\p{Pd}\p{Zs}]?   # Optional hyphenation
-      (?:
-        \d              # Digit
-        [\p{Pd}\p{Zs}]? # Optional hyphenation
-      ){9}
-      \d                # Check digit
+      (
+        97[89]            # ISBN (GS1) Bookland prefix
+        ([\p{Pd}\p{Zs}])? # Optional hyphenation
+        (?:
+          \d              # Digit
+          \2?             # Optional hyphenation
+        ){9}
+        \d                # Check digit
+      )
       \b
     /x
     ISBN_10_REGEXP = /
@@ -17,11 +19,15 @@ module Identifiers
         [\p{Pd}\p{Zs}]
       )
       \b
-      (?:
-        \d              # Digit
-        [\p{Pd}\p{Zs}]? # Optional hyphenation
-      ){9}
-      [\dX]             # Check digit
+      (
+        \d                # Digit
+        ([\p{Pd}\p{Zs}])? # Optional hyphenation
+        (?:
+          \d              # Digit
+          \2?             # Optional hyphenation
+        ){8}
+        [\dX]             # Check digit
+      )
       \b
     /x
     ISBN_A_REGEXP = %r{
@@ -46,7 +52,7 @@ module Identifiers
       str
         .to_s
         .scan(ISBN_13_REGEXP)
-        .map { |isbn| isbn.gsub(/[\p{Pd}\p{Zs}]/, '') }
+        .map { |isbn, hyphen| isbn.delete(hyphen.to_s) }
         .select { |isbn| valid_isbn_13?(isbn) }
     end
 
@@ -54,7 +60,7 @@ module Identifiers
       str
         .to_s
         .scan(ISBN_10_REGEXP)
-        .map { |isbn| isbn.gsub(/[\p{Pd}\p{Zs}]/, '') }
+        .map { |isbn, hyphen| isbn.delete(hyphen.to_s) }
         .select { |isbn| valid_isbn_10?(isbn) }
         .map { |isbn|
           isbn.chop!

--- a/spec/identifiers/isbn_spec.rb
+++ b/spec/identifiers/isbn_spec.rb
@@ -94,4 +94,12 @@ RSpec.describe Identifiers::ISBN do
   it 'does not extract ISBN-10s from space-separated ISBN-13s' do
     expect(described_class.extract('978 0 309 57079 4')).to contain_exactly('9780309570794')
   end
+
+  it 'does not extract ISBN-13s from strings with inconsistent hyphenation' do
+    expect(described_class.extract('978-0 80-506909 9')).to be_empty
+  end
+
+  it 'does not extract ISBN-10s from strings with inconsistent hyphenation' do
+    expect(described_class.extract('0-8050 6909-7')).to be_empty
+  end
 end


### PR DESCRIPTION
As we've seen some false positives in our projects where numbers separated by a mix of spaces and hyphens are incorrectly extracted as ISBNs, be a little stricter in ISBN extraction.

Specifically, only permit spaces or dashes between numbers as long as those are consistent: e.g. an ISBN separated by only spaces or only dashes but not a mix.

This means that something like 978-0-80-506909-9 is permitted but 978-0 80-506909 9 is not.

Fixes #26 