### PR TITLE
Only permit ISBNs with correct number of groups

### DIFF
--- a/lib/identifiers/isbn.rb
+++ b/lib/identifiers/isbn.rb
@@ -52,6 +52,7 @@ module Identifiers
       str
         .to_s
         .scan(ISBN_13_REGEXP)
+        .select { |isbn, hyphen| !hyphen || isbn.count(hyphen) == 4 }
         .map { |isbn, hyphen| isbn.delete(hyphen.to_s) }
         .select { |isbn| valid_isbn_13?(isbn) }
     end
@@ -60,6 +61,7 @@ module Identifiers
       str
         .to_s
         .scan(ISBN_10_REGEXP)
+        .select { |isbn, hyphen| !hyphen || isbn.count(hyphen) == 3 }
         .map { |isbn, hyphen| isbn.delete(hyphen.to_s) }
         .select { |isbn| valid_isbn_10?(isbn) }
         .map { |isbn|

--- a/spec/identifiers/isbn_spec.rb
+++ b/spec/identifiers/isbn_spec.rb
@@ -102,4 +102,20 @@ RSpec.describe Identifiers::ISBN do
   it 'does not extract ISBN-10s from strings with inconsistent hyphenation' do
     expect(described_class.extract('0-8050 6909-7')).to be_empty
   end
+
+  it 'does not extract ISBN-13s if they have more than five groups' do
+    expect(described_class.extract('978-0-80-506-909-9')).to be_empty
+  end
+
+  it 'does not extract ISBN-13s if they have less than five groups' do
+    expect(described_class.extract('978-0-80506909-9')).to be_empty
+  end
+
+  it 'does not extract ISBN-10s if they have more than four groups' do
+    expect(described_class.extract('0-8050-69-09-7')).to be_empty
+  end
+
+  it 'does not extract ISBN-10s if they have less than four groups' do
+    expect(described_class.extract('0-80506909-7')).to be_empty
+  end
 end


### PR DESCRIPTION
If an ISBN is hyphenated (either with spaces or dashes), it must be separated into a specific number of groups:

* ISBN-10s are separated into four parts (country, publisher, title, check digit)
* ISBN-13s are separated into five parts (EAN.UCC prefix, registration group, registrant, publication, check digit)

This means we can tighten up ISBN extraction further by checking that any ISBNs with hyphens have the correct number of groups for the relevant format.

See also:

* https://commerce.bowker.com/standards/home/isbn/international/hyphenation-instructions.asp
* https://www.isbn-international.org/range_file_generation