### PR TITLE
Support variable width ISBN 10 registration group IDs

### DIFF
--- a/lib/identifiers/isbn.rb
+++ b/lib/identifiers/isbn.rb
@@ -20,12 +20,12 @@ module Identifiers
       )
       \b
       (
-        \d                # Digit
+        \d{1,5}           # Registration group identifier
         ([\p{Pd}\p{Zs}])? # Optional hyphenation
         (?:
           \d              # Digit
           \2?             # Optional hyphenation
-        ){8}
+        ){4,8}
         [\dX]             # Check digit
       )
       \b
@@ -85,7 +85,7 @@ module Identifiers
     end
 
     def self.valid_isbn_13?(isbn)
-      return false unless isbn =~ ISBN_13_REGEXP
+      return false unless String(isbn).length == 13 && isbn =~ ISBN_13_REGEXP
 
       result = digits_of(isbn).zip([1, 3].cycle).map { |digit, weight| digit * weight }.reduce(:+)
 
@@ -93,7 +93,7 @@ module Identifiers
     end
 
     def self.valid_isbn_10?(isbn)
-      return false unless isbn =~ ISBN_10_REGEXP
+      return false unless String(isbn).length == 10 && isbn =~ ISBN_10_REGEXP
 
       result = digits_of(isbn).with_index.map { |digit, weight| digit * weight.succ }.reduce(:+)
 

--- a/spec/identifiers/isbn_spec.rb
+++ b/spec/identifiers/isbn_spec.rb
@@ -118,4 +118,9 @@ RSpec.describe Identifiers::ISBN do
   it 'does not extract ISBN-10s if they have less than four groups' do
     expect(described_class.extract('0-80506909-7')).to be_empty
   end
+
+  it 'extracts ISBN-10s with variable width registration group identifiers' do
+    expect(described_class.extract('99921-58-10-7 9971-5-0210-0 960-425-059-0 80-902734-1-6'))
+      .to contain_exactly('9789992158104', '9789971502102', '9789604250592', '9788090273412')
+  end
 end


### PR DESCRIPTION
As part of tightening up our hyphenation validation, we lost support for
ISBN 10s with a registration group identifier with more than one digit.
Restore support for these by permitting any registration group
identifier from 1 to 5 digits.