### PR TITLE
Add optional prefixes argument to Identifiers::ISBN.extract

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,9 +4,8 @@ project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [0.14.0] - 2024-07-30
 ### Added
-- Added optional prefixes to ISBNs extraction:
-    - extract will not match non-prefixed string when passing prefixes.
-    - It works as before without prefixes, no breaking changes, 100% backward compatible.
+- Added optional prefixes argument to ISBNs extraction.
+  If passed `.extract` will only match series of numbers that are preceded by any of the passed prefixes
 
 ## [0.13.0] - 2019-09-04
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 All notable changes to this project will be documented in this file. This
 project adheres to [Semantic Versioning](http://semver.org/).
 
+## [0.14.0] - 2024-07-30
+### Added
+- Added optional prefixes to ISBNs extraction:
+    - extract will not match non-prefixed string when passing prefixes.
+    - It works as before without prefixes, no breaking changes, 100% backward compatible.
+
 ## [0.13.0] - 2019-09-04
 ### Added
 - Added new mode to the DOI extraction, so that it doesn't strip trailing

--- a/README.md
+++ b/README.md
@@ -77,6 +77,17 @@ Identifiers::RepecId.extract('')
 Identifiers::URN.extract('')
 ```
 
+For `ISBN`s `.extract`, you can pass an array of prefixes as an optional parameter when you want to exclude matches that are not preceded by those prefixes (it is case insensitive and ignores ':' and extra whitespaces):
+
+```ruby
+Identifiers::ISBN.extract(
+  "IsBN:9789992158104  \n isbn-10 9789971502102 \n ISBN-13: 9789604250592 \n 9788090273412",
+  ["ISBN", "ISBN-10"]
+)
+# => ["9789992158104", "9789971502102"]
+```
+
+
 But for some identifiers might have more. Check [their implementation](https://github.com/altmetric/identifiers/tree/master/lib/identifiers) to see all the methods available.
 
 For `URN`s, please check the [URN gem documentation](https://github.com/altmetric/urn) to see all the available options.

--- a/identifiers.gemspec
+++ b/identifiers.gemspec
@@ -1,7 +1,7 @@
 Gem::Specification.new do |spec|
   spec.name          = 'identifiers'
-  spec.version       = '0.13.0'
-  spec.authors       = ['Jonathan Hernandez', 'Paul Mucur']
+  spec.version       = '0.14.0'
+  spec.authors       = ['Jonathan Hernandez', 'Paul Mucur', 'PatoSoft']
   spec.email         = ['support@altmetric.com']
 
   spec.summary       = 'Utilities library for various scholarly identifiers used by Altmetric'

--- a/lib/identifiers/isbn.rb
+++ b/lib/identifiers/isbn.rb
@@ -39,9 +39,23 @@ module Identifiers
       \d{1,7}   # ISBN title enumerator and check digit
       \b
     }x
+    TEXT_AFTER_PREFIX_REGEXP = ':?\s*(\d.*)$'.freeze
 
-    def self.extract(str)
+    def self.extract(str , prefixes = [])
+      str = match_strings_with_prefix(str , prefixes) if prefixes.any?
+
       extract_isbn_as(str) + extract_thirteen_digit_isbns(str) + extract_ten_digit_isbns(str)
+    end
+
+    def self.match_strings_with_prefix(str, prefixes)
+      prefix_regexp = prefixes.join('|')
+
+      str
+        .to_s
+        .scan(/(#{prefix_regexp})#{TEXT_AFTER_PREFIX_REGEXP}/i)
+        .inject('') do |acum, (_prefix, match)|
+          acum += "#{match} \n "
+        end
     end
 
     def self.extract_isbn_as(str)

--- a/lib/identifiers/isbn.rb
+++ b/lib/identifiers/isbn.rb
@@ -54,7 +54,7 @@ module Identifiers
         .to_s
         .scan(/(#{prefix_regexp})#{TEXT_AFTER_PREFIX_REGEXP}/i)
         .inject('') do |acum, (_prefix, match)|
-          acum += "#{match} \n "
+          acum + "#{match} \n "
         end
     end
 

--- a/spec/identifiers/isbn_spec.rb
+++ b/spec/identifiers/isbn_spec.rb
@@ -123,4 +123,29 @@ RSpec.describe Identifiers::ISBN do
     expect(described_class.extract('99921-58-10-7 9971-5-0210-0 960-425-059-0 80-902734-1-6'))
       .to contain_exactly('9789992158104', '9789971502102', '9789604250592', '9788090273412')
   end
+
+  context 'when passing prefixes' do
+    it 'extracts only prefixed ISBNs' do
+      text = "ISBN:9789992158104  \n ISBN-10 9789971502102 \n IsbN-13: 9789604250592 \n 9788090273412"
+      prefixes = ['IsBn', 'ISBN-10', 'ISBN-13']
+
+      expect(described_class.extract(text, prefixes))
+        .to contain_exactly('9789992158104', '9789971502102', '9789604250592')
+    end
+
+    it 'does not extract ISBNs with different prefixes' do
+      text = "ISBN:9789992158104 \n ISBN-10 9789971502102  \n IsbN-13: 9789604250592 \n 9788090273412"
+      prefixes = ['IsBn', 'ISBN-10']
+
+      expect(described_class.extract(text, prefixes))
+        .to contain_exactly('9789992158104', '9789971502102')
+    end
+
+    it 'does not extract ISBNs without prefixes' do
+      text = "9789992158104 9789971502102 9789604250592 \n 9788090273412"
+      prefixes = ['IsBn', 'ISBN-10', 'ISBN-13']
+
+      expect(described_class.extract(text, prefixes)).to be_empty
+    end
+  end
 end


### PR DESCRIPTION
**Background**
We want to prevent the method from extracting incorrect ISBNs when there are lots of numbers in the string.
We want the change to be 100% backward compatible.
We want to provide the option to pass an array of prefixes instead of using defaults.

**Changes**
For `ISBN`s `.extract`, you can pass an optional array of prefixes. 
Using that option will exclude matches that are not preceded by those prefixes
(it is case insensitive and ignores ':' and extra whitespaces):

```ruby
Identifiers::ISBN.extract(
  "IsBN:9789992158104  \n isbn-10 9789971502102 \n ISBN-13: 9789604250592 \n 9788090273412",
  ["ISBN", "ISBN-10"]
)
# => ["9789992158104", "9789971502102"]
```
