### PR TITLE
Improvements for ISBN extractor when using prefixes

### DIFF
--- a/identifiers.gemspec
+++ b/identifiers.gemspec
@@ -1,6 +1,6 @@
 Gem::Specification.new do |spec|
   spec.name          = 'identifiers'
-  spec.version       = '0.14.0'
+  spec.version       = '0.14.1'
   spec.authors       = ['Jonathan Hernandez', 'Paul Mucur', 'PatoSoft']
   spec.email         = ['support@altmetric.com']
 

--- a/lib/identifiers/isbn.rb
+++ b/lib/identifiers/isbn.rb
@@ -142,7 +142,7 @@ module Identifiers
 
     def self.isbn_a_candidate_matcher
       # We capture the ISBN-A prefix for the ISBN-A regexp to work correctly when extracting ISBN-As
-      Regexp.new(ISBN_A_REGEXP.source.gsub('(?<=10\\.)', '10\.').to_s, Regexp::IGNORECASE | Regexp::EXTENDED)
+      Regexp.new(ISBN_A_REGEXP.source.gsub('(?<=10\\.)', '10\.'), Regexp::IGNORECASE | Regexp::EXTENDED)
     end
   end
 end

--- a/lib/identifiers/isbn.rb
+++ b/lib/identifiers/isbn.rb
@@ -39,7 +39,19 @@ module Identifiers
       \d{1,7}   # ISBN title enumerator and check digit
       \b
     }x
-    TEXT_AFTER_PREFIX_REGEXP = /:?\s*(\d[^a-zA-Z]*)/
+    TEXT_AFTER_PREFIX_REGEXP = /
+      :?                    # Optional colon
+                            # If you want to use a different separator, you can add it as a prefix
+      \s*                   # Optional whitespaces
+      (                     # ISBN capture group
+        (?:
+          \d+               # ISBN Starts with a digit or more
+          ([\p{Pd}\p{Zs}])? # Optional hyphenation
+          \s?               # Optional whitespace
+        ){3,4}              # ISBN has 3 or 4 groups
+        [\dX]               # Check digit
+      )
+    /
 
     def self.extract(str , prefixes = [])
       return extract_with_prefix(str , prefixes) if prefixes.any?
@@ -49,7 +61,8 @@ module Identifiers
 
     def self.extract_with_prefix(str, prefixes)
       prefix_regexp = Regexp.union(prefixes)
-      regexp = Regexp.new("(#{prefix_regexp.source})#{TEXT_AFTER_PREFIX_REGEXP.source}", Regexp::IGNORECASE)
+      rules = (Regexp::IGNORECASE | Regexp::EXTENDED)
+      regexp = Regexp.new("(#{prefix_regexp.source})#{TEXT_AFTER_PREFIX_REGEXP.source}", rules)
 
       str
         .to_s

--- a/spec/identifiers/isbn_spec.rb
+++ b/spec/identifiers/isbn_spec.rb
@@ -133,12 +133,38 @@ RSpec.describe Identifiers::ISBN do
         .to contain_exactly('9789992158104', '9789971502102', '9789604250592')
     end
 
-    it 'extracts prefixed ISBNs with special characters, hyphens and unicode' do
+    it 'extracts ISBNs with special characters in the prefixes' do
+      text = "ISB*N:99921-58-10-7 IS?BN-10 9971-5-0210-0 Is$bN-13: 978-0-80-506909-9 80-902734-1-6"
+      prefixes = ['IsB*n', 'IS?BN-10', 'IS$BN-13']
+
+      expect(described_class.extract(text, prefixes))
+        .to contain_exactly('9789992158104', '9789971502102', '9780805069099')
+    end
+
+    it 'extracts ISBNs with Unicode dashes' do
       text = "ISB*N:99921-58-10-7 IS?BN-10 9971-5-0210-0 Is$bN-13: 978–0–80–506909–9 80-902734-1-6"
       prefixes = ['IsB*n', 'IS?BN-10', 'IS$BN-13']
 
       expect(described_class.extract(text, prefixes))
         .to contain_exactly('9789992158104', '9789971502102', '9780805069099')
+    end
+
+    it 'extracts ISBNs with Unicode spaces' do
+      text = "ISBN-13: 978 0 80 506909 9"
+      prefixes = ['ISBN-13']
+
+      expect(described_class.extract(text, prefixes)).to contain_exactly('9780805069099')
+    end
+
+    it 'normalizes 10-digit ISBNs with hyphens and a check digit of X' do
+      expect(described_class.extract('ISBN:2-7594-0269-X', ['ISBN'])).to contain_exactly('9782759402694')
+    end
+
+    it 'normalizes 10-digit ISBNs with spaces and a check digit of X' do
+      text = 'ISBN-10 2 7594 0269 X'
+      prefixes = ['ISBN-10']
+
+      expect(described_class.extract(text, prefixes)).to contain_exactly('9782759402694')
     end
 
     it 'does not extract ISBNs with different prefixes' do

--- a/spec/identifiers/isbn_spec.rb
+++ b/spec/identifiers/isbn_spec.rb
@@ -126,15 +126,23 @@ RSpec.describe Identifiers::ISBN do
 
   context 'when passing prefixes' do
     it 'extracts only prefixed ISBNs' do
-      text = "ISBN:9789992158104  \n ISBN-10 9789971502102 \n IsbN-13: 9789604250592 \n 9788090273412"
+      text = "ISBN:9789992158104  ISBN-10 9789971502102 \n IsbN-13: 9789604250592 \n 9788090273412"
       prefixes = ['IsBn', 'ISBN-10', 'ISBN-13']
 
       expect(described_class.extract(text, prefixes))
         .to contain_exactly('9789992158104', '9789971502102', '9789604250592')
     end
 
+    it 'extracts prefixed ISBNs with special characters, hyphens and unicode' do
+      text = "ISB*N:99921-58-10-7 IS?BN-10 9971-5-0210-0 Is$bN-13: 978–0–80–506909–9 80-902734-1-6"
+      prefixes = ['IsB*n', 'IS?BN-10', 'IS$BN-13']
+
+      expect(described_class.extract(text, prefixes))
+        .to contain_exactly('9789992158104', '9789971502102', '9780805069099')
+    end
+
     it 'does not extract ISBNs with different prefixes' do
-      text = "ISBN:9789992158104 \n ISBN-10 9789971502102  \n IsbN-13: 9789604250592 \n 9788090273412"
+      text = "ISBN:9789992158104 \n ISBN-10 9789971502102  IsbN-13: 9789604250592  9788090273412"
       prefixes = ['IsBn', 'ISBN-10']
 
       expect(described_class.extract(text, prefixes))

--- a/spec/identifiers/isbn_spec.rb
+++ b/spec/identifiers/isbn_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'identifiers/isbn'
 
 RSpec.describe Identifiers::ISBN do
@@ -127,14 +129,14 @@ RSpec.describe Identifiers::ISBN do
   context 'when passing prefixes' do
     it 'extracts only prefixed ISBNs' do
       text = "ISBN:9789992158104  ISBN-10 9789971502102 \n IsbN-13: 9789604250592 \n 9788090273412"
-      prefixes = ['IsBn', 'ISBN-10', 'ISBN-13']
+      prefixes = %w[IsBn ISBN-10 ISBN-13]
 
       expect(described_class.extract(text, prefixes))
         .to contain_exactly('9789992158104', '9789971502102', '9789604250592')
     end
 
     it 'extracts ISBNs with special characters in the prefixes' do
-      text = "ISB*N:99921-58-10-7 IS?BN-10 9971-5-0210-0 Is$bN-13: 978-0-80-506909-9 80-902734-1-6"
+      text = 'ISB*N:99921-58-10-7 IS?BN-10 9971-5-0210-0 Is$bN-13: 978-0-80-506909-9 80-902734-1-6'
       prefixes = ['IsB*n', 'IS?BN-10', 'IS$BN-13']
 
       expect(described_class.extract(text, prefixes))
@@ -142,7 +144,7 @@ RSpec.describe Identifiers::ISBN do
     end
 
     it 'extracts ISBNs with Unicode dashes' do
-      text = "ISB*N:99921-58-10-7 IS?BN-10 9971-5-0210-0 Is$bN-13: 978–0–80–506909–9 80-902734-1-6"
+      text = 'ISB*N:99921-58-10-7 IS?BN-10 9971-5-0210-0 Is$bN-13: 978–0–80–506909–9 80-902734-1-6'
       prefixes = ['IsB*n', 'IS?BN-10', 'IS$BN-13']
 
       expect(described_class.extract(text, prefixes))
@@ -150,7 +152,7 @@ RSpec.describe Identifiers::ISBN do
     end
 
     it 'extracts ISBNs with Unicode spaces' do
-      text = "ISBN-13: 978 0 80 506909 9"
+      text = 'ISBN-13: 978 0 80 506909 9'
       prefixes = ['ISBN-13']
 
       expect(described_class.extract(text, prefixes)).to contain_exactly('9780805069099')
@@ -167,9 +169,16 @@ RSpec.describe Identifiers::ISBN do
       expect(described_class.extract(text, prefixes)).to contain_exactly('9782759402694')
     end
 
+    it 'extracts ISBN-13s from ISBN-As' do
+      text = 'ISBN 10.978.8898392/315'
+      prefixes = %w[ISBN ISBN-10]
+
+      expect(described_class.extract(text, prefixes)).to contain_exactly('9788898392315')
+    end
+
     it 'does not extract ISBNs with different prefixes' do
       text = "ISBN:9789992158104 \n ISBN-10 9789971502102  IsbN-13: 9789604250592  9788090273412"
-      prefixes = ['IsBn', 'ISBN-10']
+      prefixes = %w[IsBn ISBN-10]
 
       expect(described_class.extract(text, prefixes))
         .to contain_exactly('9789992158104', '9789971502102')
@@ -177,7 +186,7 @@ RSpec.describe Identifiers::ISBN do
 
     it 'does not extract ISBNs without prefixes' do
       text = "9789992158104 9789971502102 9789604250592 \n 9788090273412"
-      prefixes = ['IsBn', 'ISBN-10', 'ISBN-13']
+      prefixes = %w[IsBn ISBN-10 ISBN-13]
 
       expect(described_class.extract(text, prefixes)).to be_empty
     end


### PR DESCRIPTION
- Changed ISBN extract with prefixes to be able to pick more than 1 ISBNs per line
- Improvement to allow special regex characters in prefixes
- Tests to ensure that everything works as expected when using hyphens and unicode characters
- Test to ensure it works for ISBN-A with slash
- Refactor to use the already defined regexps for ISBNS